### PR TITLE
Type the dispose callback for effect

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,7 +35,7 @@ export const computed: <T>(fn: (v: T) => T, value?: T, options?: {
  */
 export const effect: <T>(fn: (v: T) => T, value?: T, options?: {
     async?: boolean;
-}) => void;
+}) => () => void;
 /**
  * Returns a writable Signal that side-effects whenever its value gets updated.
  * @template T


### PR DESCRIPTION
The return type of `effect` was marked as `void` but the callback is returned, hence `() => void`