### PR TITLE
chore(ts): fix root type import

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "typesVersions": {
     ">=4.9": {
       "*": [
-        "types/*"
+        "types/*",
+        "types/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
`import {} from 'usingal'` lost type signatures in #20 , see https://github.com/microsoft/TypeScript/issues/43133 for details (sorry)