### PR TITLE
chore(ts): export types for signal and computed

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -90,7 +90,7 @@ const defaults = {async: false, equals: true};
 /**
  * Returns a read-only Signal that is invoked only when any of the internally
  * used signals, as in within the callback, is unknown or updated.
- * @type {<R, V, T = unknown extends V ? R : R|V>(fn: (v: T) => R, value?: V, options?: { equals?: Equals<T> }) => Omit<Computed<T>, '$'|'s'|'f'|'r'|'_'>}
+ * @type {<R, V, T = unknown extends V ? R : R|V>(fn: (v: T) => R, value?: V, options?: { equals?: Equals<T> }) => ComputedSignal<T>}
  */
 export const computed = (fn, value, options = defaults) =>
                           new Computed(fn, value, options, false);
@@ -247,11 +247,23 @@ class Reactive extends Signal {
 /**
  * Returns a writable Signal that side-effects whenever its value gets updated.
  * @template T
- * @type {<T>(initialValue: T, options?: { equals?: Equals<T> }) => Omit<Reactive<T>, '_'|'s'|'c'>}
+ * @type {<T>(initialValue: T, options?: { equals?: Equals<T> }) => ReactiveSignal<T>}
  */
 export const signal = (value, options = defaults) => new Reactive(value, options);
 
 /**
  * @template [T=any]
  * @typedef {boolean | ((prev: T, next: T) => boolean)} Equals
+ */
+
+/**
+ * @public
+ * @template T
+ * @typedef {Omit<Reactive<T>, '_'|'s'|'c'>} ReactiveSignal<T>
+ */
+
+/**
+ * @public
+ * @template T
+ * @typedef {Omit<Computed<T>, '$'|'s'|'f'|'r'|'_'>} ComputedSignal<T>
  */

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,7 +1,8 @@
-import { signal, computed } from '..'
+import { signal, computed, ReactiveSignal, ComputedSignal } from '..'
 import {expectTypeOf} from 'expect-type'
 
 const sig = signal(123)
+expectTypeOf(sig).toEqualTypeOf<ReactiveSignal<number>>()
 expectTypeOf(sig.value).toEqualTypeOf<number>()
 expectTypeOf(sig.valueOf()).toEqualTypeOf<number>()
 expectTypeOf(sig.toString()).toEqualTypeOf<string>()
@@ -11,6 +12,7 @@ expectTypeOf(await sig).toEqualTypeOf<number>()
 sig.then(v => expectTypeOf(v).toEqualTypeOf<number>())
 
 const comp = computed(() => 213)
+expectTypeOf(comp).toEqualTypeOf<ComputedSignal<number>>()
 expectTypeOf(comp.value).toEqualTypeOf<number>()
 expectTypeOf(comp.valueOf()).toEqualTypeOf<number>()
 expectTypeOf(comp.toString()).toEqualTypeOf<string>()
@@ -20,6 +22,7 @@ expectTypeOf(await comp).toEqualTypeOf<number>()
 comp.then(v => expectTypeOf(v).toEqualTypeOf<number>())
 
 const compMix = computed(() => 'asd', 123)
+expectTypeOf(compMix).toEqualTypeOf<ComputedSignal<number | string>>()
 expectTypeOf(compMix.value).toEqualTypeOf<number | string>()
 expectTypeOf(compMix.valueOf()).toEqualTypeOf<number | string>()
 expectTypeOf(compMix.toString()).toEqualTypeOf<string>()


### PR DESCRIPTION
because `Signal` can be used for `instanceof` checks, but not for describing return types of either `signal` or `computed`