### PR TITLE
test: add native-signals to benchmark

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -6,6 +6,7 @@
     "cellx": "latest",
     "cli-table": "latest",
     "kleur": "latest",
+    "native-signals": "latest",
     "s-js": "latest",
     "solid-js": "latest"
   }


### PR DESCRIPTION
Add native-signals to benchmark. Since for computeds, preact uses Push mode and native-signals uses Pull-Push model, preact will be faster without using effects.

## Results

```
┌────────────────┬───────┬────────┬────────┬─────────┬─────────┬─────────┐
│                │ 10    │ 100    │ 500    │ 1000    │ 2000    │ 2500    │
├────────────────┼───────┼────────┼────────┼─────────┼─────────┼─────────┤
│ S              │ 28.36 │ 145.38 │ 397.81 │ 1531.14 │ 2565.09 │ 5202.89 │
├────────────────┼───────┼────────┼────────┼─────────┼─────────┼─────────┤
│ solid          │ 34.90 │ 165.61 │ 706.13 │ 1593.96 │ 2632.80 │ 4277.70 │
├────────────────┼───────┼────────┼────────┼─────────┼─────────┼─────────┤
│ preact/signals │ 12.55 │ 16.93  │ 81.68  │ 143.19  │ 336.44  │ 369.33  │
├────────────────┼───────┼────────┼────────┼─────────┼─────────┼─────────┤
│ cellx          │ 21.09 │ 90.28  │ 499.98 │ 818.28  │ 2419.61 │ 3325.05 │
├────────────────┼───────┼────────┼────────┼─────────┼─────────┼─────────┤
│ usignal        │ 9.17  │ 34.35  │ 146.86 │ 274.13  │ 620.87  │ 710.36  │
├────────────────┼───────┼────────┼────────┼─────────┼─────────┼─────────┤
│ signal         │ 16.24 │ 91.74  │ 448.59 │ 1015.35 │ 2035.43 │ 2545.49 │
├────────────────┼───────┼────────┼────────┼─────────┼─────────┼─────────┤
│ native         │ 17.51 │ 18.67  │ 110.00 │ 223.96  │ 362.05  │ 604.89  │
└────────────────┴───────┴────────┴────────┴─────────┴─────────┴─────────┘
```