### PR TITLE
Fixed computed.peek to get the latest value

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,12 +12,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [22]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/esm/index.js
+++ b/esm/index.js
@@ -53,10 +53,10 @@ class Computed extends Signal {
    */
   s
   /**
-   * @param {(v: T) => T} _ 
-   * @param {T} v 
+   * @param {(v: T) => T} _
+   * @param {T} v
    * @param {{ equals?: Equals<T> }} o
-   * @param {boolean} f 
+   * @param {boolean} f
    */
   constructor(_, v, o, f) {
     super(_);
@@ -65,17 +65,23 @@ class Computed extends Signal {
     this.r = new Set;             // related signals
     this.s = new Reactive(v, o);  // signal
   }
-  peek() { return this.s.peek() }
-  get value() {
-    if (this.$) {
-      const prev = computedSignal;
-      computedSignal = this;
-      try { this.s.value = this._(this.s._) }
-      finally {
-        this.$ = false;
-        computedSignal = prev;
-      }
+  refresh() {
+    if (!this.$) return
+
+    const prev = computedSignal;
+    computedSignal = this;
+    try { this.s.value = this._(this.s._) }
+    finally {
+      this.$ = false;
+      computedSignal = prev;
     }
+  }
+  peek() {
+    this.refresh()
+    return this.s.peek()
+  }
+  get value() {
+    this.refresh()
     return this.s.value;
   }
 }
@@ -153,7 +159,7 @@ export class Effect extends FX {
 
 /**
  * Invokes a function when any of its internal signals or computed values change.
- * 
+ *
  * Returns a dispose callback.
  * @template T
  * @type {<T>(fn: (v: T) => T, value?: T, options?: { async?: boolean }) => () => void}

--- a/test/test.js
+++ b/test/test.js
@@ -248,6 +248,7 @@ export default (library, {signal, computed, effect, batch, Signal}) => {
 
     counter.value = 1;
     assert(invokes.length === 1, 'computed peek not working as expected');
+    assert(doubleCounter.peek() === 2, 'computed peek not returning right value');
   }
 
   function testComputedUniqueness() {
@@ -358,7 +359,7 @@ export default (library, {signal, computed, effect, batch, Signal}) => {
 
     assert(invokes.length === 3, 'looped effects not working');
     assert(invokes.join(',') === '0,0,1', 'looped values not matching');
-  
+
     invokes.splice(0);
     loop = 1;
     num.value = 1;


### PR DESCRIPTION
`computed.peek` is not returning the latest value.
```js
const counter = signal(0);
const doubleCounter = computed(() => counter.value * 2)

console.log(doubleCounter.peek()) // print undefined, computed callback was not executed due to laziness.
console.log(doubleCounter.value) // print 0

counter.value = 2
console.log(doubleCounter.peek()) // print 0, again, a stale value from last update is returned due to laziness.
```

this can be fixed by refreshing the internal signal's value before `peek()` into it.